### PR TITLE
fix: hpa version app common helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.1.1
+
+Fixes:
+  * autoscaling/v2 for hpa common helm charts
+
 # 4.1.0
 
 New features:

--- a/chart_deps/app/common/templates/hpa.yaml
+++ b/chart_deps/app/common/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.fullname" . }}


### PR DESCRIPTION
autoscaling/v2beta1 is deprecated in v1.23+ https://github.com/kubernetes/kube-state-metrics/issues/1711