### PR TITLE
postgres: move attributes to charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 9.3.0
+New features:
+* `postgres`:
+  * move operator resources to chart values
+  * move logical backup attributes to chart values
+  * by default use 17 postgres image
+* `environments`: get company domain attrs from `.domain` context var
+* `all charts`: new `.Values.global.bucket.type` attribute
+
 # 9.2.0
 New features:
  * `grafana/services dashboard`: new Node count pannel

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -12,6 +12,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:

--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -12,6 +12,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -16,6 +16,7 @@ registry:
   url:
 
 bucket:
+  type:
   prefix:
   suffix:
 

--- a/charts/environments/values.yaml
+++ b/charts/environments/values.yaml
@@ -12,6 +12,7 @@ network:
   int_nat_gw:
 
 bucket:
+  type:
   prefix:
   suffix:
 
@@ -28,8 +29,8 @@ defaultValuesTpl: |
     name: {{ .Values.company.name }}
     admins: {{ .Values.company.admins | toYaml | nindent 4 }}
     domain:
-      root: {{ .Values.company.domain.root }}
-      env: {{ printf "%s.%s" .env.short_name .Values.company.domain.root }}
+      root: {{ .domain.root }}
+      env: {{ .domain.env }}
   network:
     int_nat_gw: {{ .Values.network.int_nat_gw }}
   registry:
@@ -37,6 +38,7 @@ defaultValuesTpl: |
     containers:
     pip:
   bucket:
+    type: {{ .Values.bucket.type }}
     prefix: {{ .Values.company.name }}
     suffix: {{ .env.short_name }}
   repository:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -12,6 +12,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:

--- a/charts/konghq/values.yaml
+++ b/charts/konghq/values.yaml
@@ -12,6 +12,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -15,6 +15,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -14,6 +14,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:
@@ -25,16 +26,30 @@ global:
 
 postgres-operator:
   enabled: false
+  resources:
+    limits:
+      cpu: 350m
+      memory: 150Mi
+    requests:
+      cpu: 10m
+      memory: 35Mi
   configAwsOrGcp:
     wal_gs_bucket: "{{ .Values.global.bucket.prefix }}-postgres-{{ .Values.global.bucket.suffix }}"
   configLogicalBackup:
+    logical_backup_provider: "{{ .Values.global.bucket.type }}"
     logical_backup_s3_bucket: "{{ .Values.global.bucket.prefix }}-postgres-backup-{{ .Values.global.bucket.suffix }}"
-    logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.14.0"
+    logical_backup_docker_image: "{{ .Values.global.registry.url}}/pg-logical-backup:v1.14.0-1"
+  # resources for logical backup pod, if empty configPostgresPodResources will be used
+    logical_backup_cpu_limit: "2"
+    logical_backup_cpu_request: 200m
+    logical_backup_memory_limit: 500Mi
+    logical_backup_memory_request: 300Mi
   configGeneral:
     enable_crd_registration: false
-    docker_image: gramal/spilo:15-f0c5f71
+    docker_image: "{{ .Values.global.registry.url}}/spilo:v17-1"
   configMajorVersionUpgrade:
     major_version_upgrade_mode: "off"
+    target_major_version: '17'
   podServiceAccount:
     name: "postgres"
   configKubernetes:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -21,6 +21,7 @@ global:
   ingress:
     class: konghq
   bucket:
+    type:
     prefix:
     suffix:
   env:

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -12,6 +12,7 @@ global:
   registry:
     url:
   bucket:
+    type:
     prefix:
     suffix:
   ingress:


### PR DESCRIPTION
New features:
* `postgres`:
  * move operator resources to chart values
  * move logical backup attributes to chart values
  * by default use 17 postgres image
* `environments`: get company domain attrs from `.domain` context var
* `all charts`: new `.Values.global.bucket.type` attribute