### PR TITLE
thanos: charts ingresses, postgres: pgadmin under pomerium, kong: attrs to chart values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 9.5.0
+
+New features:
+  * `konghq`:
+    * move resources to chart values
+    * remove affinity rules
+    * `kong.enabled` alias
+    * move autoscaling to chart values
+  * `pomerium`: jwtClaim header for authenticated user email
+  * `postgres.pgadmin`:
+    * update pgadmin to 9.3
+    * move all common attrs to chart values
+    * enable pomerium auth for it
+  * `thanos`:
+    * create ingress resources from `chart_deps/app/core` helm lib chart
+    * `storegateway,query` ingress resources
+    * move common attrs to chart values
+
 # 9.4.0
 
 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ New features:
     * create ingress resources from `chart_deps/app/core` helm lib chart
     * `storegateway,query` ingress resources
     * move common attrs to chart values
+    * update thanos version to v0.38.0
 
 # 9.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ New features:
     * create ingress resources from `chart_deps/app/core` helm lib chart
     * `storegateway,query` ingress resources
     * move common attrs to chart values
-    * update thanos version to v0.38.0
+    * thanos app 0.37.2 -> 0.38.0
+    * thanos chart 15.14.0 -> 16.0.4
 
 # 9.4.0
 

--- a/charts/konghq/Chart.lock
+++ b/charts/konghq/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: kong
   repository: https://charts.konghq.com
   version: 2.48.0
-digest: sha256:31732fdfcc86ce622fe11e99d3af9ee661d4f06677741d83f95258f89674ab63
-generated: "2025-03-31T19:43:55.336402757Z"
+digest: sha256:5a0c5a3e7e2ec159ced540749caca2231420bce5c7d70e5bd82a9ea796f48905
+generated: "2025-05-02T13:32:28.515971548+03:00"

--- a/charts/konghq/Chart.yaml
+++ b/charts/konghq/Chart.yaml
@@ -17,3 +17,5 @@ dependencies:
   - name: kong
     version: 2.48.0
     repository: https://charts.konghq.com
+    alias: kong
+    condition: kong.enabled

--- a/charts/konghq/values.yaml
+++ b/charts/konghq/values.yaml
@@ -75,7 +75,7 @@ certificates:
               ingressClassName: "{{ .Values.global.ingress.class }}"
 
 kong:
-  enabled: true
+  enabled: false
   env:
     admin_listen: "127.0.0.1:8444 http2 ssl"
     database: "off"
@@ -119,6 +119,13 @@ kong:
       external-dns.alpha.kubernetes.io/ttl: "60"
   ingressController:
     ingressClass: konghq
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 90Mi
     admissionWebhook:
       enabled: false
       failurePolicy: Fail
@@ -129,13 +136,29 @@ kong:
       namespaceSelector: {}
       annotations:
         cert-manager.io/inject-ca-from: konghq/webhook
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: "kubernetes.io/hostname"
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: kong
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 20m
+      memory: 230Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 8
+    ## targetCPUUtilizationPercentage only used if the cluster doesn't support autoscaling/v2beta
+    targetCPUUtilizationPercentage:
+    ## Otherwise for clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 2000 # 0.4 cores
 
   podDisruptionBudget:
     enabled: true

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -76,6 +76,9 @@ pomerium:
       provider: google
       secret: '{{ .Release.Namespace }}/sso'
     secrets: '{{ .Release.Namespace }}/bootstrap'
+    jwtClaimHeaders:
+      X-Pomerium-Claim-Email: email
+
 
 gen-secrets:
   enabled: false

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -73,6 +73,19 @@ pgadmin:
   image:
     repository: dpage/pgadmin4
     tag: 8.11.0
+  environment:
+    - name: PGADMIN_DEFAULT_EMAIL
+      value: 'dev@{{ .Values.global.company.domain.root }}'
+    - name: PGADMIN_CONFIG_SERVER_MODE
+      value: 'False'
+    - name: PGADMIN_CONFIG_WTF_CSRF_ENABLED
+      value: 'False'
+    - name: PGADMIN_CONFIG_ALLOW_SAVE_PASSWORD
+      value: 'False'
+    - name: PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED
+      value: 'False'
+    - name: PGADMIN_DEFAULT_PASSWORD
+      value: 'this_is_a_stub_will_never_be_used'
   ports:
     - name: http
       containerPort: 80

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -18,7 +18,7 @@ global:
     prefix:
     suffix:
   ingress:
-    class: konghq
+    class: pomerium
   env:
     name: #aws-prd or aws-int or aws-stg
     server: #https://2.2.2.2
@@ -77,6 +77,35 @@ pgadmin:
     - name: http
       containerPort: 80
       protocol: TCP
+  initContainers:
+    volumeperm:
+      image: busybox
+      command: ["sh", "-c", "chown -R 5050:5050 /var/lib/pgadmin"]
+  pvcs:
+    configs:
+      storage: 1Gi
+      mountPath: /var/lib/pgadmin
+  ingress:
+    enabled: false
+    className: "{{ .Values.global.ingress.class }}"
+    annotations:
+      cert-manager.io/cluster-issuer: '{{ printf "letsencrypt-%s" .Values.global.ingress.class }}'
+      ingress.pomerium.io/policy: |
+        allow:
+          or:
+            {{- range $email := .Values.global.company.admins.emails }}
+            - email:
+                is: {{ $email }}
+            {{- end }}
+    hosts:
+      - host: 'pg.{{ .Values.global.company.domain.env }}'
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: pgadmin-tls
+        hosts:
+          - 'pg.{{ .Values.global.company.domain.env }}'
 
 postgres-main:
   enabled: false

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -76,8 +76,6 @@ pgadmin:
   environment:
     - name: PGADMIN_DEFAULT_EMAIL
       value: 'dev@{{ .Values.global.company.domain.root }}'
-    - name: PGADMIN_CONFIG_SERVER_MODE
-      value: 'False'
     - name: PGADMIN_CONFIG_WTF_CSRF_ENABLED
       value: 'False'
     - name: PGADMIN_CONFIG_ALLOW_SAVE_PASSWORD
@@ -86,6 +84,10 @@ pgadmin:
       value: 'False'
     - name: PGADMIN_DEFAULT_PASSWORD
       value: 'this_is_a_stub_will_never_be_used'
+    - name: PGADMIN_CONFIG_AUTHENTICATION_SOURCES
+      value: '["webserver"]'
+    - name: PGADMIN_CONFIG_WEBSERVER_REMOTE_USER
+      value: '"X-Pomerium-Claim-Email"'
   ports:
     - name: http
       containerPort: 80

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -72,7 +72,7 @@ pgadmin:
   enabled: false
   image:
     repository: dpage/pgadmin4
-    tag: 8.11.0
+    tag: 9.3.0
   environment:
     - name: PGADMIN_DEFAULT_EMAIL
       value: 'dev@{{ .Values.global.company.domain.root }}'

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -105,6 +105,7 @@ pgadmin:
     className: "{{ .Values.global.ingress.class }}"
     annotations:
       cert-manager.io/cluster-issuer: '{{ printf "letsencrypt-%s" .Values.global.ingress.class }}'
+      ingress.pomerium.io/pass_identity_headers: 'true'
       ingress.pomerium.io/policy: |
         allow:
           or:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -439,8 +439,8 @@ prometheus-main:
     spec:
       enableAdminAPI: true
       thanos:
-        image: quay.io/thanos/thanos:v0.37.2
-        version: v0.37.2
+        image: quay.io/thanos/thanos:v0.38.0
+        version: v0.38.0
         objectStorageConfig:
           key: objstore.yml
           name: thanos

--- a/charts/thanos/Chart.lock
+++ b/charts/thanos/Chart.lock
@@ -4,6 +4,9 @@ dependencies:
   version: 0.1.0
 - name: thanos
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.14.0
-digest: sha256:51b99063545388e930fdca42aa62acf1aab8c5470626b3dafe14e5481c27d9a5
-generated: "2025-04-01T20:44:18.287079645Z"
+  version: 16.0.4
+- name: core
+  repository: file://../chart_deps/app/core
+  version: 0.1.0
+digest: sha256:0678730427b697a2a74ff97a58a25805f9ff59673d25bead3ff55b07d0470933
+generated: "2025-04-30T14:50:43.937123959+03:00"

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -26,6 +26,9 @@ dependencies:
   #https://github.com/bitnami/charts/tree/main/bitnami/thanos
   - name: thanos
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 15.14.0
+    version: 16.0.4
     alias: thanos
     condition: thanos.enabled
+  - name: core
+    version: 0.1.0
+    repository: file://../chart_deps/app/core

--- a/charts/thanos/templates/_helpers.tpl
+++ b/charts/thanos/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thanos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "thanos.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "thanos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "thanos.labels" -}}
+helm.sh/chart: {{ include "thanos.chart" . }}
+{{ include "thanos.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "thanos.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thanos.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/thanos/templates/ingresses.yaml
+++ b/charts/thanos/templates/ingresses.yaml
@@ -1,0 +1,5 @@
+{{- range $ingress_name, $ingress_obj := .Values.ingresses }}
+{{- $labels := include "thanos.labels" $ | fromYaml }}
+{{- $labels := set $labels "app.kubernetes.io/component"  $ingress_name }}
+{{- include "core.ingress" (list $ (toYaml $labels) $ingress_obj )}}
+{{- end }}

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -28,7 +28,7 @@ ingresses:
     name: '{{ include "thanos.fullname" . }}-query'
     service:
       name: '{{ include "thanos.fullname" . }}-query'
-      port: 80
+      port: 9090
     className: pomerium
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-pomerium

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -22,25 +22,108 @@ global:
     server: #https://2.2.2.2
     short_name: #pre/prd/int/dev/etc
 
+ingresses:
+  query:
+    enabled: false
+    name: '{{ include "thanos.fullname" . }}-query'
+    service:
+      name: '{{ include "thanos.fullname" . }}-query'
+      port: 80
+    className: pomerium
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-pomerium
+      ingress.pomerium.io/policy: |
+        allow:
+          or:
+            {{- range $email := .Values.global.company.admins.emails }}
+            - email:
+                is: {{ $email }}
+            {{- end }}
+
+    hosts:
+      - host: "tq.{{ .Values.global.company.domain.env }}"
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: tq-tls
+        hosts:
+          - "tq.{{ .Values.global.company.domain.env }}"
+  storegateway:
+    enabled: false
+    name: '{{ include "thanos.fullname" . }}-storegateway-grpc'
+    service:
+      name: '{{ include "thanos.fullname" . }}-storegateway'
+      port: 10901
+    className: "{{ .Values.global.ingress.class }}"
+    annotations:
+      cert-manager.io/cluster-issuer: '{{ printf "letsencrypt-%s" .Values.global.ingress.class }}'
+      konghq.com/protocols: grpc,grpcs
+      konghq.com/plugins: thanos-store-main-ip-restriction
+    hosts:
+      - host: "thanos-store.{{ .Values.global.company.domain.env }}"
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: thanos-store-tls
+        hosts:
+          - "thanos-store.{{ .Values.global.company.domain.env }}"
+
+
 kong-plugins:
   enabled: false
+  plugins:
+    - name: thanos-store-main-ip-restriction
+      plugin_name: ip-restriction
+      annotations:
+        kubernetes.io/ingress.class: '{{ .Values.global.ingress.class }}'
+      config:
+        allow:
+          - "{{ .Values.global.network.int_nat_gw }}"
 
 thanos:
   enabled: false
-  existingObjstoreSecret: ""
+  existingObjstoreSecret: "thanos"
   query:
     enabled: false
+    dnsDiscovery:
+      enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
   queryFrontend:
     enabled: false
   bucketweb:
     enabled: false
   compactor:
     enabled: false
+    resources:
+      requests:
+        cpu: 20m
+        memory: 45Mi
+      limits:
+        cpu: 1500m
+        memory: 1Gi
     serviceAccount:
       create: false
       name: thanos
   storegateway:
     enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    service:
+      annotations:
+        konghq.com/protocol: grpc
     serviceAccount:
       create: false
       name: thanos


### PR DESCRIPTION
New features:
  * `konghq`:
    * move resources to chart values
    * remove affinity rules
    * `kong.enabled` alias
    * move autoscaling to chart values
  * `pomerium`: jwtClaim header for authenticated user email
  * `postgres.pgadmin`:
    * update pgadmin to 9.3
    * move all common attrs to chart values
    * enable pomerium auth for it
  * `thanos`:
    * create ingress resources from `chart_deps/app/core` helm lib chart
    * `storegateway,query` ingress resources
    * move common attrs to chart values